### PR TITLE
Update demo and repo URLs to point to itsbrex fork

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This document provides guidance for AI assistants working with the ACID Pattern 
 
 The ACID Pattern Generator is a web-based music sequencer for creating TB-303-style acid house sequences. Inspired by "STING by SKINNERBOX" Max for Live device, it features algorithmic pattern generation with interactive editing.
 
-**Live demo:** https://drakh.github.io/acid-generator/
+**Live demo:** https://itsbrex.github.io/acid-generator/
 
 ### Key Features
 - Generative pattern sequencer with density, spread, accents, and slides controls

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Rationale behind is that as i am mainly web developer i wanted to create prototy
 as plugin for [**Mod Dwarf**](https://mod.audio/dwarf/)
 Main focus is on generating the sequence not the 303 sound.
 
-[Live demo](https://drakh.github.io/acid-generator/)
+[Live demo](https://itsbrex.github.io/acid-generator/)
 
-[Repository](https://github.com/drakh/acid-generator)
+[Repository](https://github.com/itsbrex/acid-generator) (forked from [drakh/acid-generator](https://github.com/drakh/acid-generator))
 
 ## USAGE
 


### PR DESCRIPTION
The live demo and repository links in README.md and CLAUDE.md
pointed to the original drakh/acid-generator repo. Updated them
to itsbrex/acid-generator so the fork's GitHub Pages deployment
can be previewed. The original repo is still credited as upstream.

https://claude.ai/code/session_01NugBdzTJxNWFFYDS7yEb2A