### PR TITLE
Modernize GitHub Actions workflows for fork deployment

### DIFF
--- a/.github/workflows/gh-pages-publish.yml
+++ b/.github/workflows/gh-pages-publish.yml
@@ -1,47 +1,51 @@
-name: Build and deploy
-
-permissions:
-  contents: write
+name: Build and deploy to GitHub Pages
 
 on:
   push:
     branches:
       - master
-  release:
-    branches:
-      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
-      - name: Node install
-        uses: actions/setup-node@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
 
       - name: Build
-        run: npm run build --if-present
+        run: npm run build
 
-      - name: Pwd
-        run: pwd
-
-      - name: Ls
-        run: ls -la
-
-      - name: RM
-        run: rm -rf ./.gitignore
-
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          folder: dist # The folder the action should deploy.
-          force: true
+          path: dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,13 +16,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        node-version: [18.x, 20.x]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'


### PR DESCRIPTION
- gh-pages-publish.yml: Switch from JamesIves deploy action (pushes to gh-pages branch) to official actions/deploy-pages (uses GitHub Pages API directly). Add workflow_dispatch for manual triggers. Update to Node 20 and actions v4.
- node.js.yml: Update Node matrix from 16/18 to 18/20, bump actions to v4.

The repo Pages setting must be set to "GitHub Actions" as the source (Settings > Pages > Source) for deployment to work.

https://claude.ai/code/session_01NugBdzTJxNWFFYDS7yEb2A