### PR TITLE
fix: move Google Fonts import from LESS to HTML link tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="dns-prefetch" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Comfortaa:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/src/index.less
+++ b/src/index.less
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@300;400;500;600;700&display=swap');
 @import "colors";
 
 * {


### PR DESCRIPTION
LESS `@import url()` fetches the font CSS at build time, which fails
in CI environments without external network access. Moving it to an
HTML `<link>` tag defers loading to the browser at runtime.

https://claude.ai/code/session_01FNib9AfmFTbuaC4fwtEzBJ