### PR TITLE
fix: hide README on mobile, fix horizontal overflow

### DIFF
--- a/src/components/About.module.less
+++ b/src/components/About.module.less
@@ -44,10 +44,6 @@
 
 @media (max-width: 768px) {
   .about {
-    padding: 1rem 0.75rem;
-
-    header, h1, h2, h3, h4 {
-      font-size: 1.4rem;
-    }
+    display: none;
   }
 }

--- a/src/components/Sequencer.module.less
+++ b/src/components/Sequencer.module.less
@@ -38,19 +38,25 @@
 // Mobile: reduce piano roll height, better scroll UX
 @media (max-width: 768px) {
   .sequencer {
+    width: 100%;
+    max-width: 100%;
+
     main {
       height: 16rem;
       border-radius: 4px;
       border: 1px solid rgba(67, 187, 153, 0.2);
 
       div {
-        min-width: 40rem;
+        min-width: 32rem;
       }
     }
 
     footer {
+      width: 100%;
+
       section {
         margin-bottom: 0.5rem;
+        flex-wrap: wrap;
       }
     }
   }

--- a/src/components/sequencer/SynthControls.module.less
+++ b/src/components/sequencer/SynthControls.module.less
@@ -18,9 +18,12 @@
   .synthControls {
     justify-content: center;
     gap: 0.25rem;
+    width: 100%;
+    max-width: 100%;
 
     li {
       margin-left: 0;
+      flex: 0 0 auto;
     }
   }
 }

--- a/src/index.less
+++ b/src/index.less
@@ -19,11 +19,14 @@
 
 html {
   height: -webkit-fill-available;
+  overflow-x: hidden;
 }
 
 body {
   min-height: 100vh;
   min-height: -webkit-fill-available;
+  overflow-x: hidden;
+  width: 100%;
 }
 
 :root {
@@ -47,6 +50,9 @@ body {
   padding-left: env(safe-area-inset-left);
   padding-right: env(safe-area-inset-right);
   align-items: flex-start;
+  width: 100%;
+  max-width: 100vw;
+  overflow-x: hidden;
 
   .storedPatterns {
     min-width: 20rem;


### PR DESCRIPTION
## Problem

On mobile the app was showing the full `README.md` (rendered via the `About` component) as the primary content — making it feel like a documentation page rather than a synthesizer app. On top of that, content was bleeding horizontally past the viewport edge on iOS.

## Changes

**Hide README on mobile (`About.module.less`)**
- `display: none` on `≤768px` — the README adds zero value on small viewports; users should see only the synth UI
- Still visible on desktop as before

**Fix horizontal overflow (`index.less`)**
- `overflow-x: hidden` on `html`, `body`, and `#root`
- `width: 100%` + `max-width: 100vw` on `#root`

**Tighten sequencer on mobile (`Sequencer.module.less`)**
- Piano roll `min-width` reduced from `40rem` → `32rem` on mobile
- `width: 100%` + `max-width: 100%` on `.sequencer`
- Footer sections set to `flex-wrap: wrap`

**Constrain SynthControls (`SynthControls.module.less`)**
- `width: 100%` + `max-width: 100%` on mobile
- List items set to `flex: 0 0 auto` to prevent overflow